### PR TITLE
Fix cannot auto login in 2022

### DIFF
--- a/extension/google_accounts.js
+++ b/extension/google_accounts.js
@@ -28,6 +28,16 @@ function gacGetLoginElements() {
 function gacPerformLogin(email) {
     if (DEBUG) console.log("gacPerformLogin: %s", email);
     let loginElements = gacGetLoginElements();
+
+
+    // Auto click the first account if there is only one
+    if (loginElements.length == 1) {
+        let el = loginElements[0];
+        el.click();
+        return true;
+    }
+
+    // Find and click if the account match given email
     for (let i = 0; i < loginElements.length; i++) {
         let el = loginElements[i];
         let elEmail = el.getAttribute("data-identifier");
@@ -38,6 +48,7 @@ function gacPerformLogin(email) {
             return true;
         }
     }
+
     if (DEBUG) console.log("gacPerformLogin: did not match any");
     return false;
 }

--- a/extension/google_accounts.js
+++ b/extension/google_accounts.js
@@ -4,6 +4,7 @@
 //
 
 const DEBUG = false;
+const DELAY_LOGIN_MILLISECONDS = 500;
 
 if (DEBUG) console.log("google_account.js - in like Flynn!");
 
@@ -30,12 +31,7 @@ function gacPerformLogin(email) {
     let loginElements = gacGetLoginElements();
 
 
-    // Auto click the first account if there is only one
-    if (loginElements.length == 1) {
-        let el = loginElements[0];
-        el.click();
-        return true;
-    }
+
 
     // Find and click if the account match given email
     for (let i = 0; i < loginElements.length; i++) {
@@ -72,11 +68,21 @@ function gacClickHandler(domain, el) {
 
 function gacStartup() {
     let domain = gacGetDomain();
+    let loginElements = gacGetLoginElements();
 
     // Register click handlers
-    gacGetLoginElements().forEach(
+    loginElements.forEach(
         el => el.addEventListener("click", gacClickHandler(domain, el), false)
     );
+
+    // Auto click the first account if there is only one
+    if (loginElements.length == 1) {
+        setTimeout(() => {
+            let el = loginElements[0];
+            el.click();
+        }, DELAY_LOGIN_MILLISECONDS);
+        return;
+    }
 
     // Try to see if we should log in automatically.
     chrome.runtime.sendMessage(
@@ -87,7 +93,7 @@ function gacStartup() {
         function (response) {
             if (response !== undefined) {
                 if (response.email) {
-                    setTimeout(gacPerformLogin, 500, response.email);
+                    setTimeout(gacPerformLogin, DELAY_LOGIN_MILLISECONDS, response.email);
                 }
             }
         }

--- a/extension/google_accounts.js
+++ b/extension/google_accounts.js
@@ -15,7 +15,7 @@ function gacGetDomain() {
         }
         return domain;
     }
-    catch(err) {
+    catch (err) {
         if (DEBUG) console.log("Problem getting domain from referrer:", err.mesasge);
         return "NONE";
     }
@@ -73,10 +73,10 @@ function gacStartup() {
             action: "getEmail",
             domain: domain
         },
-        function(response) {
-            if (response !== undefined)  {
+        function (response) {
+            if (response !== undefined) {
                 if (response.email) {
-                    gacPerformLogin(response.email)
+                    setTimeout(gacPerformLogin, 500, response.email);
                 }
             }
         }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -25,6 +25,7 @@
   "content_scripts": [
     {
       "matches": [
+        "https://accounts.google.com/o/oauth2/*",
         "https://accounts.google.com/o/oauth2/auth/oauthchooseaccount?*",
         "https://accounts.google.com/AccountChooser/signinchooser?*"
       ],


### PR DESCRIPTION
In 2020, Google is has a new version of OAuth (v2) and the plugin stops working.
This PR contains the fixes to make it work again:

- Support new OAuth v2 URL
- Add delay when performing login, looks like Google does this to prevent bots
